### PR TITLE
Added option to change cutoff score

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use this tool you will need:
 
 1. python3 
     - [biopython](http://biopython.org/)
-    - [scikit-learn](http://scikit-learn.org)  
+    - [scikit-learn 0.20.0](http://scikit-learn.org)  
 2. [CPAT v1.2.1](http://rna-cpat.sourceforge.net/)
     - python2
 3. [DIAMOND](https://github.com/bbuchfink/diamond)
@@ -76,8 +76,8 @@ The columns describe:
 2. length of transcript
 3. ORF length
 4. GC%
-5. Fickett score (for more info see the CPAT paper)
-6. Hexamer score (for more info see the CPAT paper)
+5. Fickett score (for more info see the [CPAT paper](https://academic.oup.com/nar/article/41/6/e74/2902455))
+6. Hexamer score (for more info see the [CPAT paper](https://academic.oup.com/nar/article/41/6/e74/2902455))
 7. % identity to a hit in the SwissProt database
 8. Alignment length of hit in SwissProt database
 9. Ratio of alignment length to transcript lenth

--- a/README.md
+++ b/README.md
@@ -90,3 +90,15 @@ The other files may be less useful to you, depending on what you're looking at.
 `all_model_predictions.csv`: how each base model predicted the transcript (1 == lncRNA).   
 `all_model_scores.csv`: the lncRNA prediction scores of each transcript for each base model.  
 `ensemble_logreg_pred.csv`: the raw output of the final logistic regression stacking classifier.  
+
+## Arguments
+
+```
+Required arguments:
+    -f	input fasta file
+    -c	output file from CPAT run
+    -d	output file from Diamond blastx
+
+Ooptional arguments:
+    -s	minimum lncRNA prediction score (Default: 0.5)
+```

--- a/bin/predict.py
+++ b/bin/predict.py
@@ -22,6 +22,7 @@ parser = argparse.ArgumentParser(description="predict lncRNAs from transcript se
 parser.add_argument("-f", "--fasta", dest="trans_fasta", required=True, metavar="transcript.fa", help="fasta file of transcript sequences for prediction")
 parser.add_argument("-c", "--cpat_out", dest="cpat_out", required=True, metavar="cpat_out.csv", help="CPAT output of transcript sequences")
 parser.add_argument("-d", "--diamond_out", dest="diam_out", required=True, metavar="diamond_out.tab", help="Diamond output of transcript sequences")
+parser.add_argument("-s", "--score_cutoff", dest="score_cut", type=float, default=0.5, metavar="s", help="Minimum cutoff score for the lncRNA prediction (Default: 0.5)")
 
 args = parser.parse_args()
 
@@ -95,7 +96,7 @@ with open(os.path.join(fasta_path,"ensemble_logreg_pred.csv")) as pred:
         name = name.lower()
         score = row[1]
         trans_dict[name]["lnc_score"] = score
-        if float(score) >= 0.5:
+        if float(score) >= args.score_cut:
             trans_dict[name]["prediction"] = 1
         else:
             trans_dict[name]["prediction"] = 0  

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ ruamel.yaml==0.15.88
 scikit-learn==0.20.2
 scipy==1.1.0
 six==1.11.0
-sklearn==0.0
+sklearn==0.20.0
 statsmodels==0.9.0
 treeinterpreter==0.2.2
 urllib3==1.24.1


### PR DESCRIPTION
Hi Caitlin! Here's a little thing that I found helpful for myself when running crema. The optional flag `-s` will allow you to change the score cutoff value for prediction = 1 or prediction = 0. I gave it the default value of 0.5 like the original method. I also added the sklearn requirements in the Readme because I ran into some one or two functions being depreciated in the newer versions.